### PR TITLE
Fix for Local scope variable shadows member

### DIFF
--- a/src/TheChest.Core/Slots/LazyStackSlot.cs
+++ b/src/TheChest.Core/Slots/LazyStackSlot.cs
@@ -148,17 +148,17 @@ namespace TheChest.Core.Slots
         }
         /// <inheritdoc/>
         /// <exception cref="ArgumentNullException">When <paramref name="item"/> is null</exception>
-        public virtual bool Contains(T item, int amount)
+        public virtual bool Contains(T item, int requiredAmount)
         {
             if (item is null)
                 throw new ArgumentNullException(nameof(item));
-            if (amount <= 0)
-                throw new ArgumentOutOfRangeException(nameof(amount));
+            if (requiredAmount <= 0)
+                throw new ArgumentOutOfRangeException(nameof(requiredAmount));
 
             if (this.IsEmpty)
                 return false;
             return item.Equals(this.content) && 
-                amount <= this.Amount;
+                requiredAmount <= this.Amount;
         }
     }
 }


### PR DESCRIPTION
To fix the problem in general, avoid using local variables or parameters that have the same name (case‑insensitive in C#) as instance or static members of the class. Instead, choose parameter/local names that clearly describe their role without colliding with member names.

For this specific case, the best fix with no functional change is to rename the method parameter `amount` in `public virtual bool Contains(T item, int amount)` to something that does not shadow the member, such as `requiredAmount` (or `quantity`, etc.), and update its uses within the method accordingly. This keeps the method semantics identical—still validating the passed value, still comparing it against `this.Amount`—while eliminating the shadowing.

Concretely, in `src/TheChest.Core/Slots/LazyStackSlot.cs`, around lines 150‑162, change the parameter name in the method signature from `amount` to `requiredAmount`, and change both references to that parameter (`if (amount <= 0)` and `amount <= this.Amount`) to `requiredAmount`. No other files or members need modification, and no additional imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._