### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_library.workflow.yml
+++ b/.github/workflows/publish_library.workflow.yml
@@ -5,6 +5,9 @@ on:
      tags:        
       - "**"
 
+permissions:
+  contents: read
+
 env:
   PROJECT_NAME: "TheChest.Core"
 
@@ -35,6 +38,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
   


### PR DESCRIPTION
Potential fix for [https://github.com/The-Chest/TheChest.Core/security/code-scanning/5](https://github.com/The-Chest/TheChest.Core/security/code-scanning/5)

Add explicit `permissions` blocks to the workflow so each job has only the minimum required scope.

Best fix here without changing behavior:
- Add a root-level `permissions` with `contents: read` as baseline.
- Override permissions for the `publish` job to include `contents: write` because it uploads release artifacts and likely needs write access to repository contents/releases.
- Keep `build` job effectively read-only.

File to change:
- `.github/workflows/publish_library.workflow.yml`

No imports, methods, or dependencies are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
