### PR TITLE
Add unit tests for Array extension methods `ToGenericArray` and `ToObjectArray`

### DIFF
--- a/tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.cs
+++ b/tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.cs
@@ -1,0 +1,85 @@
+﻿using TheChest.Core.Slots.Extensions;
+using TheChest.Core.Tests.Common.Configurations;
+using TheChest.Core.Tests.Common.Configurations.Attributes;
+using TheChest.Core.Tests.Common.Items.Interfaces;
+using TheChest.Core.Tests.Common.Items.ReferenceType;
+using TheChest.Core.Tests.Common.Items.ValueType;
+
+namespace TheChest.Core.Tests.Extensions
+{
+    [TestFixture(typeof(TestItem))]
+    [TestFixture(typeof(TestStructItem))]
+    [TestFixture(typeof(TestEnumItem))]
+    public class ArrayExtensionsTests<T> : BaseTest<T>
+    {
+        private readonly IItemFactory<T> itemFactory;
+
+        public ArrayExtensionsTests() : base(_ => { })
+        {
+            this.itemFactory = this.configurations.Resolve<IItemFactory<T>>();
+        }
+
+        [Test]
+        public void ToGenericArray_NullArray_ThrowsArgumentNullException()
+        {
+            object[] array = null!;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => array.ToGenericArray<T>());
+
+            Assert.That(exception!.ParamName, Is.EqualTo("array"));
+        }
+
+        [Test]
+        public void ToGenericArray_ArrayContainsNulls_ReturnsTypedArrayWithoutNulls()
+        {
+            var first = this.itemFactory.CreateRandom();
+            var second = this.itemFactory.CreateRandom();
+            object[] array = new object[] { first!, null!, second!, null! };
+
+            var result = array.ToGenericArray<T>();
+
+            Assert.That(result, Is.EqualTo(new[] { first, second }));
+        }
+
+        [Test]
+        public void ToObjectArray_NullArray_ThrowsArgumentNullException()
+        {
+            T[] array = null!;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => array.ToObjectArray());
+
+            Assert.That(exception!.ParamName, Is.EqualTo("array"));
+        }
+
+        [Test]
+        [IgnoreIfReferenceType]
+        public void ToObjectArray_ValueTypeArray_ReturnsObjectArrayWithAllValues()
+        {
+            var first = this.itemFactory.CreateRandom();
+            var second = this.itemFactory.CreateRandom();
+            var array = new[] { first, second };
+
+            var result = array.ToObjectArray();
+
+            Assert.That(result, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result[0], Is.EqualTo(first));
+                Assert.That(result[1], Is.EqualTo(second));
+            });
+        }
+
+        [Test]
+        [IgnoreIfValueType]
+        public void ToObjectArray_ReferenceTypeArrayContainsNulls_ReturnsObjectArrayWithoutNulls()
+        {
+            var first = this.itemFactory.CreateRandom();
+            var second = this.itemFactory.CreateRandom();
+            var array = new[] { first, default!, second, default! };
+
+            var result = array.ToObjectArray();
+
+            Assert.That(result, Is.EqualTo(new object[] { first!, second! }));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Add coverage for array extension helpers to ensure correct behavior when arrays are null or contain null elements, and to validate handling of value and reference types.
- Prevent regressions in conversion logic by exercising both generic and object-returning extension methods across different item types.

### Description
- Added `tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.cs` with a generic NUnit test fixture `ArrayExtensionsTests<T>` instantiated for `TestItem`, `TestStructItem`, and `TestEnumItem`.
- Implemented tests for `ToGenericArray<T>()` including `ToGenericArray_NullArray_ThrowsArgumentNullException` and `ToGenericArray_ArrayContainsNulls_ReturnsTypedArrayWithoutNulls`.
- Implemented tests for `ToObjectArray()` including `ToObjectArray_NullArray_ThrowsArgumentNullException`, `ToObjectArray_ValueTypeArray_ReturnsObjectArrayWithAllValues` (ignored for reference types), and `ToObjectArray_ReferenceTypeArrayContainsNulls_ReturnsObjectArrayWithoutNulls` (ignored for value types).
- Tests use the existing test infrastructure (`BaseTest<T>`, `IItemFactory<T>`, and `IgnoreIfReferenceType` / `IgnoreIfValueType` attributes) to create items and conditionally skip tests.

### Testing
- Ran the test suite for `tests/TheChest.Core.Tests` with `dotnet test` which executed the new `ArrayExtensionsTests` cases.
- All new tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e22e1042dc832383e5bc67bca2ae9e)