### PR TITLE
Split ArrayExtensions tests into partial files and add GetAdjacentEqualCount tests

### DIFF
--- a/tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.cs
+++ b/tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.cs
@@ -1,6 +1,4 @@
-﻿using TheChest.Core.Extensions;
-using TheChest.Core.Tests.Common.Configurations;
-using TheChest.Core.Tests.Common.Configurations.Attributes;
+﻿using TheChest.Core.Tests.Common.Configurations;
 using TheChest.Core.Tests.Common.Items.Interfaces;
 using TheChest.Core.Tests.Common.Items.ReferenceType;
 using TheChest.Core.Tests.Common.Items.ValueType;
@@ -10,66 +8,13 @@ namespace TheChest.Core.Tests.Extensions
     [TestFixture(typeof(TestItem))]
     [TestFixture(typeof(TestStructItem))]
     [TestFixture(typeof(TestEnumItem))]
-    public class ArrayExtensionsTests<T> : BaseTest<T>
+    public partial class ArrayExtensionsTests<T> : BaseTest<T>
     {
         private readonly IItemFactory<T> itemFactory;
 
         public ArrayExtensionsTests() : base(_ => { })
         {
             this.itemFactory = this.configurations.Resolve<IItemFactory<T>>();
-        }
-
-        [Test]
-        public void ToGenericArray_ArrayContainsNulls_ReturnsTypedArrayWithoutNulls()
-        {
-            var first = this.itemFactory.CreateRandom();
-            var second = this.itemFactory.CreateRandom();
-            var array = new object[] { first!, null!, second!, null! };
-
-            var result = array.ToGenericArray<T>();
-
-            Assert.That(result, Is.EqualTo(new[] { first, second }));
-        }
-
-        [Test]
-        public void ToObjectArray_NullArray_ThrowsArgumentNullException()
-        {
-            T[] array = null!;
-
-            var exception = Assert.Throws<ArgumentNullException>(() => array.ToObjectArray());
-
-            Assert.That(exception!.ParamName, Is.EqualTo("array"));
-        }
-
-        [Test]
-        [IgnoreIfReferenceType]
-        public void ToObjectArray_ValueTypeArray_ReturnsObjectArrayWithAllValues()
-        {
-            var first = this.itemFactory.CreateRandom();
-            var second = this.itemFactory.CreateRandom();
-            var array = new[] { first, second };
-
-            var result = array.ToObjectArray();
-
-            Assert.That(result, Has.Length.EqualTo(2));
-            Assert.Multiple(() =>
-            {
-                Assert.That(result[0], Is.EqualTo(first));
-                Assert.That(result[1], Is.EqualTo(second));
-            });
-        }
-
-        [Test]
-        [IgnoreIfValueType]
-        public void ToObjectArray_ReferenceTypeArrayContainsNulls_ReturnsObjectArrayWithoutNulls()
-        {
-            var first = this.itemFactory.CreateRandom();
-            var second = this.itemFactory.CreateRandom();
-            var array = new[] { first, default!, second, default! };
-
-            var result = array.ToObjectArray();
-
-            Assert.That(result, Is.EqualTo(new object[] { first!, second! }));
         }
     }
 }

--- a/tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.get_adjacent_equal_count.cs
+++ b/tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.get_adjacent_equal_count.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.Generic;
+using TheChest.Core.Extensions;
+
+namespace TheChest.Core.Tests.Extensions
+{
+    public partial class ArrayExtensionsTests<T>
+    {
+        [Test]
+        public void GetAdjacentEqualCount_NoAdjacentEqualItems_ReturnsStartIndex()
+        {
+            var first = this.itemFactory.CreateRandom();
+            var second = this.CreateRandomDifferentFrom(first);
+            var array = new[] { first, second };
+
+            var result = array.GetAdjacentEqualCount(startIndex: 0, maxCount: 5);
+
+            Assert.That(result, Is.EqualTo(0));
+        }
+
+        [Test]
+        public void GetAdjacentEqualCount_AdjacentEqualItemsExist_ReturnsLastAdjacentIndex()
+        {
+            var first = this.itemFactory.CreateRandom();
+            var second = this.CreateRandomDifferentFrom(first);
+            var array = new[] { first, first, first, second };
+
+            var result = array.GetAdjacentEqualCount(startIndex: 0, maxCount: 10);
+
+            Assert.That(result, Is.EqualTo(2));
+        }
+
+        [Test]
+        public void GetAdjacentEqualCount_AdjacentEqualItemsExceedMaxCount_ReturnsIndexLimitedByMaxCount()
+        {
+            var item = this.itemFactory.CreateRandom();
+            var array = new[] { item, item, item, item };
+
+            var result = array.GetAdjacentEqualCount(startIndex: 0, maxCount: 2);
+
+            Assert.That(result, Is.EqualTo(1));
+        }
+
+        [Test]
+        public void GetAdjacentEqualCount_StartIndexHasPreviousEqualItems_OnlyCountsForwardFromStartIndex()
+        {
+            var first = this.itemFactory.CreateRandom();
+            var second = this.CreateRandomDifferentFrom(first);
+            var array = new[] { second, first, first, first };
+
+            var result = array.GetAdjacentEqualCount(startIndex: 1, maxCount: 10);
+
+            Assert.That(result, Is.EqualTo(3));
+        }
+
+        [Test]
+        public void GetAdjacentEqualCount_MaxCountIsOne_ReturnsStartIndex()
+        {
+            var item = this.itemFactory.CreateRandom();
+            var array = new[] { item, item, item };
+
+            var result = array.GetAdjacentEqualCount(startIndex: 0, maxCount: 1);
+
+            Assert.That(result, Is.EqualTo(0));
+        }
+
+        private T CreateRandomDifferentFrom(T item)
+        {
+            var comparer = EqualityComparer<T>.Default;
+            var candidate = this.itemFactory.CreateRandom();
+
+            for (int i = 0; i < 10 && comparer.Equals(candidate, item); i++)
+            {
+                candidate = this.itemFactory.CreateRandom();
+            }
+
+            if (comparer.Equals(candidate, item))
+            {
+                Assert.Inconclusive("Unable to generate a distinct test value.");
+            }
+
+            return candidate;
+        }
+    }
+}

--- a/tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.to_generic_array.cs
+++ b/tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.to_generic_array.cs
@@ -1,0 +1,19 @@
+﻿using TheChest.Core.Extensions;
+
+namespace TheChest.Core.Tests.Extensions
+{
+    public partial class ArrayExtensionsTests<T>
+    {
+        [Test]
+        public void ToGenericArray_ArrayContainsNulls_ReturnsTypedArrayWithoutNulls()
+        {
+            var first = this.itemFactory.CreateRandom();
+            var second = this.itemFactory.CreateRandom();
+            var array = new object[] { first!, null!, second!, null! };
+
+            var result = array.ToGenericArray<T>();
+
+            Assert.That(result, Is.EqualTo(new[] { first, second }));
+        }
+    }
+}

--- a/tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.to_object_array.cs
+++ b/tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.to_object_array.cs
@@ -1,0 +1,49 @@
+﻿using TheChest.Core.Extensions;
+using TheChest.Core.Tests.Common.Configurations.Attributes;
+
+namespace TheChest.Core.Tests.Extensions
+{
+    public partial class ArrayExtensionsTests<T>
+    {
+        [Test]
+        public void ToObjectArray_NullArray_ThrowsArgumentNullException()
+        {
+            T[] array = null!;
+
+            var exception = Assert.Throws<ArgumentNullException>(() => array.ToObjectArray());
+
+            Assert.That(exception!.ParamName, Is.EqualTo("array"));
+        }
+
+        [Test]
+        [IgnoreIfReferenceType]
+        public void ToObjectArray_ValueTypeArray_ReturnsObjectArrayWithAllValues()
+        {
+            var first = this.itemFactory.CreateRandom();
+            var second = this.itemFactory.CreateRandom();
+            var array = new[] { first, second };
+
+            var result = array.ToObjectArray();
+
+            Assert.That(result, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result[0], Is.EqualTo(first));
+                Assert.That(result[1], Is.EqualTo(second));
+            });
+        }
+
+        [Test]
+        [IgnoreIfValueType]
+        public void ToObjectArray_ReferenceTypeArrayContainsNulls_ReturnsObjectArrayWithoutNulls()
+        {
+            var first = this.itemFactory.CreateRandom();
+            var second = this.itemFactory.CreateRandom();
+            var array = new[] { first, default!, second, default! };
+
+            var result = array.ToObjectArray();
+
+            Assert.That(result, Is.EqualTo(new object[] { first!, second! }));
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Make the `ArrayExtensionsTests<T>` test class modular so each extension's tests live in their own partial file for clarity and maintenance.
- Add focused unit tests for `GetAdjacentEqualCount` to cover edge cases and expected traversal behavior.

### Description
- Converted `ArrayExtensionsTests<T>` into a `partial` class and moved shared fixture setup and `itemFactory` initialization into `tests/TheChest.Core.Tests/Extensions/ArrayExtensionsTests.cs`.
- Created `ArrayExtensionsTests.to_generic_array.cs` containing the `ToGenericArray` test and `ArrayExtensionsTests.to_object_array.cs` containing the `ToObjectArray` tests with existing conditional attributes preserved.
- Added `ArrayExtensionsTests.get_adjacent_equal_count.cs` with tests for `GetAdjacentEqualCount` covering no-adjacent items, contiguous adjacent items, `maxCount` limiting, forward-only counting from a non-zero `startIndex`, and `maxCount == 1` behavior, and included a small helper `CreateRandomDifferentFrom` to reduce random collisions.
- Kept existing usings and test fixtures and added `using System.Collections.Generic;` where needed for comparisons.

### Testing
- Ran `dotnet test tests/TheChest.Core.Tests/TheChest.Core.Tests.csproj` and the full test suite passed.
- Test run completed with only pre-existing nullable warnings in unrelated files and no new test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e873aba2808323986ce5190ce6bbb8)