### PR TITLE
Fix off-by-one in ToStackSlots slicing and add unit tests

### DIFF
--- a/src/TheChest.Core/Slots/Extensions/StackSlotExtensions.cs
+++ b/src/TheChest.Core/Slots/Extensions/StackSlotExtensions.cs
@@ -17,7 +17,7 @@ namespace TheChest.Core.Slots.Extensions
                 var startIndex = index;
                 var endIndex = items.GetAdjacentEqualCount(startIndex, maxStackSize);
 
-                slots.Add(new StackSlot<T>(items[startIndex..endIndex], maxStackSize));
+                slots.Add(new StackSlot<T>(items[startIndex..(endIndex + 1)], maxStackSize));
 
                 index = endIndex + 1;
             }

--- a/tests/TheChest.Core.Tests/Extensions/StackSlotExtensions/StackSlotExtensions.cs
+++ b/tests/TheChest.Core.Tests/Extensions/StackSlotExtensions/StackSlotExtensions.cs
@@ -1,0 +1,20 @@
+﻿using TheChest.Core.Tests.Common.Configurations;
+using TheChest.Core.Tests.Common.Items.Interfaces;
+using TheChest.Core.Tests.Common.Items.ReferenceType;
+using TheChest.Core.Tests.Common.Items.ValueType;
+
+namespace TheChest.Core.Tests.Extensions
+{
+    [TestFixture(typeof(TestItem))]
+    [TestFixture(typeof(TestStructItem))]
+    [TestFixture(typeof(TestEnumItem))]
+    public partial class StackSlotExtensions<T> : BaseTest<T>
+    {
+        private readonly IItemFactory<T> itemFactory;
+
+        public StackSlotExtensions() : base(_ => { })
+        {
+            this.itemFactory = this.configurations.Resolve<IItemFactory<T>>();
+        }
+    }
+}

--- a/tests/TheChest.Core.Tests/Extensions/StackSlotExtensions/StackSlotExtensions.to_stack_slot.cs
+++ b/tests/TheChest.Core.Tests/Extensions/StackSlotExtensions/StackSlotExtensions.to_stack_slot.cs
@@ -1,0 +1,51 @@
+﻿using TheChest.Core.Slots.Extensions;
+
+namespace TheChest.Core.Tests.Extensions
+{
+    public partial class StackSlotExtensions<T>
+    {
+        [Test]
+        public void ToStackSlots_EmptyItems_ReturnsEmptySlotsArray()
+        {
+            var items = System.Array.Empty<T>();
+
+            var result = items.ToStackSlots(maxStackSize: 3);
+
+            Assert.That(result, Is.Empty);
+        }
+
+        [Test]
+        public void ToStackSlots_AdjacentEqualItemsExceedMaxStackSize_SplitsIntoMultipleSlots()
+        {
+            var item = this.itemFactory.CreateRandom();
+            var items = new[] { item, item, item };
+
+            var result = items.ToStackSlots(maxStackSize: 2);
+
+            Assert.That(result, Has.Length.EqualTo(2));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result[0].Amount, Is.EqualTo(2));
+                Assert.That(result[0].Contains(item), Is.True);
+                Assert.That(result[1].Amount, Is.EqualTo(1));
+                Assert.That(result[1].Contains(item), Is.True);
+            });
+        }
+
+        [Test]
+        public void ToStackSlots_AdjacentEqualItemsWithinMaxStackSize_CreatesSingleSlot()
+        {
+            var item = this.itemFactory.CreateRandom();
+            var items = new[] { item, item };
+
+            var result = items.ToStackSlots(maxStackSize: 3);
+
+            Assert.That(result, Has.Length.EqualTo(1));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result[0].Amount, Is.EqualTo(2));
+                Assert.That(result[0].Contains(item), Is.True);
+            });
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Correct an off-by-one error when creating stack slots from adjacent equal items so all matching items are included in a slot.
- Provide coverage for `ToStackSlots` behavior across empty arrays, splitting when the adjacent equal count exceeds `maxStackSize`, and normal grouping within the `maxStackSize` limit.

### Description
- Adjusted slicing in `StackSlotExtensions.ToStackSlots<T>` to use `items[startIndex..(endIndex + 1)]` so the last adjacent item returned by `GetAdjacentEqualCount` is included in the slot.
- Added a test fixture `StackSlotExtensions<T>` with concrete test item types and three unit tests for `ToStackSlots`: handling empty input, splitting when exceeding `maxStackSize`, and creating a single slot when within `maxStackSize`.

### Testing
- Added and executed unit tests under `tests/TheChest.Core.Tests/Extensions/StackSlotExtensions`, including `ToStackSlots_EmptyItems_ReturnsEmptySlotsArray`, `ToStackSlots_AdjacentEqualItemsExceedMaxStackSize_SplitsIntoMultipleSlots`, and `ToStackSlots_AdjacentEqualItemsWithinMaxStackSize_CreatesSingleSlot`, and they passed.
- Ran the test suite with `dotnet test` for the modified project and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e87a8a200c83239621ab0b01fc6864)