### PR TITLE
StackSlotExtensions: validate maxStackSize, bound endIndex, pre-size slots and add tests

### DIFF
--- a/src/Slots/Extensions/StackSlotExtensions.cs
+++ b/src/Slots/Extensions/StackSlotExtensions.cs
@@ -9,14 +9,20 @@ namespace TheChest.Core.Slots.Extensions
     {
         internal static IStackSlot<T>[] ToStackSlots<T>(this T[] items, int maxStackSize)
         {
+            if (maxStackSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxStackSize), "Max stack size must be greater than zero.");
+
             var index = 0;
 
-            var slots = new List<IStackSlot<T>>(items.Length);
+            var slots = new List<IStackSlot<T>>((items.Length + maxStackSize - 1) / maxStackSize);
 
             while (index < items.Length)
             {
                 var startIndex = index;
-                var endIndex = items.GetAdjacentEqualCount(startIndex, maxStackSize) + 1;
+                var endIndex = Math.Min(
+                    items.GetAdjacentEqualCount(startIndex, maxStackSize) + 1,
+                    items.Length
+                );
 
                 var amountToAdd = endIndex - startIndex;
                 var itemsToAdd = new T[amountToAdd];

--- a/tests/Extensions/StackSlotExtensions/StackSlotExtensions.to_stack_slot.cs
+++ b/tests/Extensions/StackSlotExtensions/StackSlotExtensions.to_stack_slot.cs
@@ -33,6 +33,38 @@ namespace TheChest.Core.Tests.Extensions
         }
 
         [Test]
+        public void ToStackSlots_NoAdjacentEqualItems_CreatesOneSlotPerItem()
+        {
+            var firstItem = this.itemFactory.CreateRandom();
+            var secondItem = this.itemFactory.CreateDifferentFrom(firstItem);
+            var thirdItem = this.itemFactory.CreateDifferentFrom(secondItem);
+            var items = new[] { firstItem, secondItem, thirdItem };
+
+            var result = items.ToStackSlots(maxStackSize: 3);
+
+            Assert.That(result, Has.Length.EqualTo(items.Length));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result[0].Amount, Is.EqualTo(1));
+                Assert.That(result[0].Contains(firstItem), Is.True);
+                Assert.That(result[1].Amount, Is.EqualTo(1));
+                Assert.That(result[1].Contains(secondItem), Is.True);
+                Assert.That(result[2].Amount, Is.EqualTo(1));
+                Assert.That(result[2].Contains(thirdItem), Is.True);
+            });
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void ToStackSlots_MaxStackSizeIsZeroOrLess_ThrowsArgumentOutOfRangeException(int maxStackSize)
+        {
+            var item = this.itemFactory.CreateRandom();
+            var items = new[] { item };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => items.ToStackSlots(maxStackSize));
+        }
+
+        [Test]
         public void ToStackSlots_AdjacentEqualItemsWithinMaxStackSize_CreatesSingleSlot()
         {
             var item = this.itemFactory.CreateRandom();


### PR DESCRIPTION
### Motivation
- Ensure `ToStackSlots` handles invalid `maxStackSize` input and avoids out-of-range indexing when computing slot ranges.
- Improve performance by estimating the list capacity to reduce reallocations when building slot arrays.

### Description
- Added an argument check in `StackSlotExtensions.ToStackSlots<T>` to throw `ArgumentOutOfRangeException` when `maxStackSize <= 0`.
- Compute an estimated capacity using ceiling division and initialize the `List<IStackSlot<T>>` with that capacity to reduce allocations.
- Clamp `endIndex` with `Math.Min(..., items.Length)` to prevent reading past the array bounds when calculating adjacent-equal ranges.
- Added unit tests: `ToStackSlots_NoAdjacentEqualItems_CreatesOneSlotPerItem` and `ToStackSlots_MaxStackSizeIsZeroOrLess_ThrowsArgumentOutOfRangeException` to cover the new behaviors.

### Testing
- Ran the test suite covering `StackSlotExtensions` unit tests, including the newly added tests in `tests/Extensions/StackSlotExtensions`, and they all passed.
- Existing tests for adjacent-equal splitting (`ToStackSlots_AdjacentEqualItemsExceedMaxStackSize_SplitsIntoMultipleSlots` and `ToStackSlots_AdjacentEqualItemsWithinMaxStackSize_CreatesSingleSlot`) were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a08dd2e9884832383eecd0f3579fda2)