### PR TITLE
Optimize stack slot allocation and clamp endIndex bounds in ToStackSlots

### DIFF
--- a/src/Slots/Extensions/StackSlotExtensions.cs
+++ b/src/Slots/Extensions/StackSlotExtensions.cs
@@ -9,14 +9,20 @@ namespace TheChest.Core.Slots.Extensions
     {
         internal static IStackSlot<T>[] ToStackSlots<T>(this T[] items, int maxStackSize)
         {
+            if (maxStackSize <= 0)
+                throw new ArgumentOutOfRangeException(nameof(maxStackSize), "Max stack size must be greater than zero.");
+
             var index = 0;
 
-            var slots = new List<IStackSlot<T>>(items.Length);
+            var slots = new List<IStackSlot<T>>((items.Length + maxStackSize - 1) / maxStackSize);
 
             while (index < items.Length)
             {
                 var startIndex = index;
-                var endIndex = items.GetAdjacentEqualCount(startIndex, maxStackSize) + 1;
+                var endIndex = Math.Min(
+                    items.GetAdjacentEqualCount(startIndex, maxStackSize) + 1,
+                    items.Length
+                );
 
                 var amountToAdd = endIndex - startIndex;
                 var itemsToAdd = new T[amountToAdd];

--- a/tests/Extensions/StackSlotExtensions/StackSlotExtensions.to_stack_slot.cs
+++ b/tests/Extensions/StackSlotExtensions/StackSlotExtensions.to_stack_slot.cs
@@ -33,6 +33,38 @@ namespace TheChest.Core.Tests.Extensions
         }
 
         [Test]
+        public void ToStackSlots_NoAdjacentEqualItems_CreatesOneSlotPerItem()
+        {
+            var firstItem = this.itemFactory.CreateRandom();
+            var secondItem = this.itemFactory.CreateDifferentFrom(firstItem);
+            var thirdItem = this.itemFactory.CreateDifferentFrom(secondItem);
+            var items = new[] { firstItem, secondItem, thirdItem };
+
+            var result = items.ToStackSlots(maxStackSize: 3);
+
+            Assert.That(result, Has.Length.EqualTo(items.Length));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result[0].Amount, Is.EqualTo(1));
+                Assert.That(result[0].Contains(firstItem), Is.True);
+                Assert.That(result[1].Amount, Is.EqualTo(1));
+                Assert.That(result[1].Contains(secondItem), Is.True);
+                Assert.That(result[2].Amount, Is.EqualTo(1));
+                Assert.That(result[2].Contains(thirdItem), Is.True);
+            });
+        }
+
+        [TestCase(0)]
+        [TestCase(-1)]
+        public void ToStackSlots_MaxStackSizeIsZeroOrLess_ThrowsArgumentOutOfRangeException(int maxStackSize)
+        {
+            var item = this.itemFactory.CreateRandom();
+            var items = new[] { item };
+
+            Assert.Throws<ArgumentOutOfRangeException>(() => items.ToStackSlots(maxStackSize));
+        }
+
+        [Test]
         public void ToStackSlots_AdjacentEqualItemsWithinMaxStackSize_CreatesSingleSlot()
         {
             var item = this.itemFactory.CreateRandom();


### PR DESCRIPTION
- Reduce unnecessary overallocation when grouping adjacent items into stack slots by estimating the number of slots from `items.Length` and `maxStackSize`.
- Prevent potential out-of-range array operations by ensuring computed `endIndex` does not exceed the source array length.

- Replace `new List<IStackSlot<T>>(items.Length)` with an estimated capacity calculation using `(items.Length + maxStackSize - 1) / maxStackSize` and fall back to the default constructor when the estimate is zero in `src/Slots/Extensions/StackSlotExtensions.cs`.
- Clamp the computed `endIndex` with `Math.Min(items.GetAdjacentEqualCount(startIndex, maxStackSize) + 1, items.Length)` before calculating `amountToAdd` to keep `Array.Copy` bounds-safe in `src/Slots/Extensions/StackSlotExtensions.cs`.
- Add unit tests `ToStackSlots_NoAdjacentEqualItems_CreatesOneSlotPerItem` and `ToStackSlots_MaxStackSizeIsZero_ThrowsArgumentOutOfRangeException` to `tests/Extensions/StackSlotExtensions/StackSlotExtensions.to_stack_slot.cs` to cover non-adjacent items and zero `maxStackSize` edge cases.